### PR TITLE
Worker p

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -15,6 +15,8 @@ def main(global_config, **settings):
                         session_factory=session_factory,
                         root_factory='fishtest.models.RootFactory')
 
+  config.include('pyramid_mako')
+
   # Authentication
   with open(os.path.expanduser('~/fishtest.secret'), 'r') as f:
     secret = f.read()

--- a/fishtest/setup.py
+++ b/fishtest/setup.py
@@ -8,6 +8,7 @@ CHANGES = ''
 requires = [
     'pyramid',
     'pyramid_debugtoolbar',
+    'pyramid_mako',
     'waitress',
     'pymongo',
     'scipy',

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -26,7 +26,7 @@ from games import run_games
 from updater import update
 from datetime import datetime
 
-WORKER_VERSION = 67
+WORKER_VERSION = 68
 ALIVE = True
 
 HTTP_TIMEOUT = 15.0


### PR DESCRIPTION
    Make the worker calculate the pentanomial frequencies.
    
    There are no server changes in this patch.
    
    The updated worker will send the pentanomial frequencies
    to the server and the server will faithfully store them in
    its databaese as it does with all information received from
    the client.
    
    I checked that the server changes necessary to make
    effective use of the pentanomial frequencies are quite minor.
    This will be the subject of some subsequent PR's.
    
    I am making this PR now so that the worker changes can be reviewed.
    
    The actual logic added to the worker is quite minor.
    A dictionary "rounds" keeps track of the finished games. For every
    finished game pair (which consists of an odd numbered game
    and the next even numbered game) the pentanomial frequencies
    are updated.
    
    Since sending incorrect frequencies to the server would
    be quite distastrous, a lot of sanity checking is done to
    make sure that the pentanomial frequencies are consistent
    with the trinomial frequencies provided by cutechess itself.
    
    I have tested the updated worker on my local copy of fishtest.
